### PR TITLE
Feature/multiple channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,11 @@ This terraform module creates AWS Chatbot and its dependencies.
 The following resources will be created:
 
  - An Identity and Access Management (IAM)
- - AWS Chatbot
- - Simple Notification Service(SNS) topic to connect to AWS Chatbot
 
 In addition you have the option to:
 
- - Create aws chatboot and integrate to slack
- - Create a Slack channel id to send budget notification using AWS Chatbot
- - Create a Slack workspace id to send budget notification using AWS Chatbot
+ - Create aws chatboot workspace(s) and integrate to slack
+ - Create AWS chatbot clients connecting to one or more slack channel(s) to send notification using AWS Chatbot
 
 <!--- BEGIN_TF_DOCS --->
 
@@ -36,17 +33,22 @@ In addition you have the option to:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | alarm\_sns\_topic\_arns | SNS Topic ARN(s) to connect to AWS Chatbot | `list(string) or string` | n/a | yes |
-| enabled | If true, will create aws chatboot and integrate to slack | `string` | `"false"` | no |
+| enabled | If true, will create aws chatbots | `string` | `"false"` | no |
 | logging_level | Specifies the logging level for this configuration. This property affects the log entries pushed to Amazon CloudWatch Logs. Logging levels include ERROR, INFO, or NONE. | `string` | ERROR | no |
 | org\_name | Name for this organization | `any` | n/a | yes |
 | slack\_channel\_id | Slack channel id to send budget notfication using AWS Chatbot | `string` | `""` | no |
 | slack\_workspace\_id | Slack workspace id to send budget notfication using AWS Chatbot | `string` | `""` | no |
+| slack\_ids | Use to define additional slack channels. Format: [ { channel = xxx, workspace=xxx } ] | `map` | `{}` | no |
 | tags | Specifies object tags key and value. This applies to all resources created by this module. | `map` | <pre>{<br>  "Terraform": true<br>}</pre> | no |
 | workspace\_name | Description for the chat integration | `any` | n/a | yes |
 
 ## Outputs
 
-No output.
+| Name | Description |
+|------|-------------|
+| role_arn | The ARN of the Chatbot role |
+| role_name | The name of the Chatbot role |
+| slack_arns | A map of the Chatbot Slack configurations ARNs |
 
 <!--- END_TF_DOCS --->
 

--- a/_locals.tf
+++ b/_locals.tf
@@ -1,0 +1,23 @@
+
+locals {
+
+  primary_name = "${var.org_name}-${var.workspace_name}"
+
+  primary_target = (var.slack_channel_id != "" && var.slack_workspace_id != "") ? {
+    (local.primary_name) = {
+      channel   = var.slack_channel_id
+      workspace = var.slack_workspace_id
+  } } : {}
+
+  # Priority to primary target if names conflict
+
+  slack_targets = merge(var.slack_ids, local.primary_target)
+
+  # Outputs
+
+  stacks     = (var.enabled ? aws_cloudformation_stack.tf_chatbot : {})
+  slack_arns = { for k, v in local.stacks : k => v.outputs.ConfigurationArn }
+}
+
+# For debugging only
+#output stacks { value = local.stacks }

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -1,20 +1,15 @@
 
-output "stack_id" {
-  description = "The unique identifier for the stack."
-  value       = var.enabled ? aws_cloudformation_stack.tf_chatbot[0].id : ""
-}
-
-output "stack_arn" {
-  description = "The ARN of the Chatbot Slack configuration"
-  value       = var.enabled ?  aws_cloudformation_stack.tf_chatbot[0].outputs.ConfigurationArn : ""
+output slack_arns {
+  description = "A map of the Chatbot Slack configurations ARNs"
+  value       = local.slack_arns
 }
 
 output role_name {
   description = "The name of the Chatbot role"
-  value       = var.enabled ?  aws_iam_role.chatbot[0].name : ""
+  value       = var.enabled ? aws_iam_role.chatbot[0].name : ""
 }
 
 output role_arn {
   description = "The ARN of the Chatbot role"
-  value       = var.enabled ?  aws_iam_role.chatbot[0].arn : ""
+  value       = var.enabled ? aws_iam_role.chatbot[0].arn : ""
 }

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -1,0 +1,20 @@
+
+output "stack_id" {
+  description = "The unique identifier for the stack."
+  value       = var.enabled ? aws_cloudformation_stack.tf_chatbot[0].id : ""
+}
+
+output "stack_arn" {
+  description = "The ARN of the Chatbot Slack configuration"
+  value       = var.enabled ?  aws_cloudformation_stack.tf_chatbot[0].outputs.ConfigurationArn : ""
+}
+
+output role_name {
+  description = "The name of the Chatbot role"
+  value       = var.enabled ?  aws_iam_role.chatbot[0].name : ""
+}
+
+output role_arn {
+  description = "The ARN of the Chatbot role"
+  value       = var.enabled ?  aws_iam_role.chatbot[0].arn : ""
+}

--- a/_variables.tf
+++ b/_variables.tf
@@ -16,6 +16,13 @@ variable "slack_workspace_id" {
   description = "Slack workspace id to send budget notfication using AWS Chatbot"
   default     = ""
 }
+
+variable slack_ids {
+  description = "Use to define additional slack channels. Format: [ { channel = xxx, workspace=xxx }"
+  default     = {}
+  type        = any
+}
+
 variable "alarm_sns_topic_arns" {
   description = "ARN of SNS Topic(s) to connect to AWS Chatbot"
   # list of string (accept string for backwards compatibility)
@@ -25,6 +32,7 @@ variable "alarm_sns_topic_arns" {
 
 variable "tags" {
   description = "Specifies object tags key and value. This applies to all resources created by this module."
+  type        = map(string)
   default = {
     "Terraform" = true
   }

--- a/cf-chatbot.yml
+++ b/cf-chatbot.yml
@@ -37,3 +37,8 @@ Resources:
         !Ref SnsTopicArnsParam
       LoggingLevel:
         !Ref LoggingLevelParam
+
+Outputs:
+  ConfigurationArn:
+    Description: The ARN of the Chatbot Slack configuration
+    Value: !Ref Chatbot

--- a/chatbot.tf
+++ b/chatbot.tf
@@ -3,17 +3,17 @@ resource "aws_cloudformation_stack" "tf_chatbot" {
   name  = "terraform-chatbot-${var.org_name}-${var.workspace_name}"
   parameters = {
     ConfigurationNameParam = "${var.org_name}-${var.workspace_name}"
-    IamRoleArnArnParam     = aws_iam_role.chatbot-role.*.arn[0]
+    IamRoleArnArnParam     = aws_iam_role.chatbot.*.arn[0]
     SnsTopicArnsParam      = join(",",flatten([var.alarm_sns_topic_arns]))
     SlackChannelIdParam    = var.slack_channel_id
     SlackWorkspaceIdParam  = var.slack_workspace_id
-    LoggingLevelParameter  = var.logging_level
+    LoggingLevelParam      = var.logging_level
   }
   template_body = file("${path.module}/cf-chatbot.yml")
 }
 
 
-resource "aws_iam_role" "chatbot-role" {
+resource aws_iam_role chatbot {
   count              = var.enabled ? 1 : 0
   name               = "${var.org_name}-${var.workspace_name}-chatbot-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role_chatbot.*.json[0]
@@ -22,7 +22,7 @@ resource "aws_iam_role" "chatbot-role" {
 
 resource "aws_iam_role_policy_attachment" "chatbot_policy" {
   count      = var.enabled ? 1 : 0
-  role       = aws_iam_role.chatbot-role.*.name[0]
+  role       = aws_iam_role.chatbot.*.name[0]
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 data "aws_iam_policy_document" "assume_role_chatbot" {

--- a/chatbot.tf
+++ b/chatbot.tf
@@ -1,17 +1,24 @@
+
+# Note that the same configuration name cannot appear more than once, even in different slack
+# workspaces.
+
 resource "aws_cloudformation_stack" "tf_chatbot" {
-  count = var.enabled ? 1 : 0
-  name  = "terraform-chatbot-${var.org_name}-${var.workspace_name}"
+  for_each = var.enabled ? local.slack_targets : {}
+
+  name = "terraform-chatbot-${each.key}"
+
   parameters = {
-    ConfigurationNameParam = "${var.org_name}-${var.workspace_name}"
+    ConfigurationNameParam = each.key
     IamRoleArnArnParam     = aws_iam_role.chatbot.*.arn[0]
-    SnsTopicArnsParam      = join(",",flatten([var.alarm_sns_topic_arns]))
-    SlackChannelIdParam    = var.slack_channel_id
-    SlackWorkspaceIdParam  = var.slack_workspace_id
+    SnsTopicArnsParam      = join(",", flatten([var.alarm_sns_topic_arns]))
+    SlackChannelIdParam    = each.value.channel
+    SlackWorkspaceIdParam  = each.value.workspace
     LoggingLevelParam      = var.logging_level
   }
   template_body = file("${path.module}/cf-chatbot.yml")
 }
 
+#--------------
 
 resource aws_iam_role chatbot {
   count              = var.enabled ? 1 : 0
@@ -20,11 +27,14 @@ resource aws_iam_role chatbot {
   tags               = var.tags
 }
 
+#--------------
+
 resource "aws_iam_role_policy_attachment" "chatbot_policy" {
   count      = var.enabled ? 1 : 0
   role       = aws_iam_role.chatbot.*.name[0]
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
+
 data "aws_iam_policy_document" "assume_role_chatbot" {
   count = var.enabled ? 1 : 0
   statement {


### PR DESCRIPTION
My slack environment includes several slack workspaces, with people authorized to access a subset of these workspaces/channels only. So, it is important for me to transmit events to more than one slack channel, so that different teams with different access rights see it in their team-specific workspace.

This PR preserves backwards compatibility by combining old & new input variables but it does not preserve compatibility with the previous PR creating output variables, as it was not published yet.